### PR TITLE
Fix filename issues when creating with absfile

### DIFF
--- a/src/tagui_header.js
+++ b/src/tagui_header.js
@@ -771,7 +771,8 @@ if (filename.substr(0,1) == '/') return filename; // return mac/linux absolute f
 if (filename.substr(1,1) == ':') return filename.replace(/\\/g,'/'); // return windows absolute filename directly
 var tmp_flow_path = flow_path; // otherwise use flow_path defined in generated script to build absolute filename
 // above str_replace is because casperjs/phantomjs do not seem to support \ for windows paths, replace with / to work
-if (tmp_flow_path.indexOf('/') > -1) return tmp_flow_path + '/' + filename; else return tmp_flow_path + '\\' + filename;}
+if (tmp_flow_path.indexOf('/') > -1) return (tmp_flow_path + '/' + filename).replace(/\\/g,'/');
+else return tmp_flow_path + '\\' + filename;}
 
 function add_concat(source_string) { // parse string and add missing + concatenator
 if ((source_string.indexOf("'") > -1) && (source_string.indexOf('"') > -1))

--- a/src/tagui_parse.php
+++ b/src/tagui_parse.php
@@ -441,7 +441,8 @@ if (strpos($filename,"'+")!==false and strpos($filename,"+'")!==false)
 return "'+abs_file('" . $filename . "')+'"; // throw to runtime abs_file function if dynamic filename is given
 $flow_path = str_replace("\\","/",dirname($flow_script)); // otherwise use flow script path to build absolute filename
 // above str_replace is because casperjs/phantomjs do not seem to support \ for windows paths, replace with / to work
-if (strpos($flow_path,"/")!==false) return $flow_path . '/' . $filename; else return $flow_path . '\\' . $filename;} 
+if (strpos($flow_path,"/")!==false) return str_replace("\\","/",$flow_path . '/' . $filename);
+else return $flow_path . '\\' . $filename;} 
 
 function beg_tx($locator) { // helper function to return beginning string for handling locators
 if ($GLOBALS['inside_while_loop'] == 0)


### PR DESCRIPTION
Fix issue discussed in #200 to ensure file paths created by abs_file() use only one type of slash.

Checked to work correctly on Windows and Mac/Linux.