### PR TITLE
Include present/visible Sikuki integration

### DIFF
--- a/src/tagui.sikuli/tagui.py
+++ b/src/tagui.sikuli/tagui.py
@@ -146,6 +146,14 @@ def vision_intent ( raw_intent ):
 	print '[tagui] ACTION - ' + params
 	exec(params,globals())
 	return 1
+	
+def visible_intent ( raw_intent ):
+	params = (raw_intent + ' ')[1+(raw_intent + ' ').find(' '):].strip()
+	print '[tagui] ACTION - check if present/visible ' + params
+	if exists(params):
+		return 1
+	else:
+		return 0
 
 # function to interpret input intent
 def get_intent ( raw_intent ):
@@ -171,6 +179,8 @@ def get_intent ( raw_intent ):
 		return 'snap'
 	if raw_intent[:7].lower() == 'vision ':
 		return 'vision'
+	if raw_intent[:8].lower() == 'visible ' or raw_intent[:8].lower() == 'present ':
+		return 'visible';
 	return 'error'
 
 # function to parse and act on intent
@@ -198,6 +208,8 @@ def parse_intent ( script_line ):
 		return snap_intent(script_line)
 	elif intent_type == 'vision':
 		return vision_intent(script_line)
+	elif intent_type == 'visible':
+		return visible_intent(script_line);
 	else:
 		return 0 
 

--- a/src/tagui.sikuli/tagui.py
+++ b/src/tagui.sikuli/tagui.py
@@ -148,8 +148,7 @@ def vision_intent ( raw_intent ):
 	return 1
 	
 def visible_intent ( raw_intent ):
-	params = (raw_intent + ' ')[1+(raw_intent + ' ').find(' '):].strip()
-	print '[tagui] ACTION - check if present/visible ' + params
+	print '[tagui] ACTION - ' + raw_intent.strip()
 	if exists(params):
 		return 1
 	else:

--- a/src/tagui_header.js
+++ b/src/tagui_header.js
@@ -202,13 +202,24 @@ return false;}
  */
 
 // friendlier name to use check_tx() in if condition in flow
-function present(element_locator) {if (!element_locator) return false; else return check_tx(element_locator);}
+function present(element_locator) {if (!element_locator) return false; 
+if (is_sikuli(element_locator))
+{abs_param = abs_file(element_locator); var fs = require('fs');
+if (!fs.exists(abs_param)) {this.echo('ERROR - cannot find image file for present step').exit();}
+if (sikuli_step("present " + abs_param)) return true;
+else return false;}
+else return check_tx(element_locator);}
 
 // friendlier name to check element visibility using elementVisible()
 function visible(element_locator) {if (!element_locator) return false;
-var element_located = tx(element_locator); var element_visible = casper.elementVisible(element_located);
+if (is_sikuli(element_locator))
+{abs_param = abs_file(element_locator); var fs = require('fs');
+if (!fs.exists(abs_param)) {this.echo('ERROR - cannot find image file for visible step').exit();}
+if (sikuli_step("visible " + abs_param)) return true;
+else return false;}
+else {var element_located = tx(element_locator); var element_visible = casper.elementVisible(element_located);
 // if tx() returns x('/html') means that the element is not found, so set element_visible to false
-if (element_located.toString() == x('/html').toString()) element_visible = false; return element_visible;}
+if (element_located.toString() == x('/html').toString()) element_visible = false; return element_visible;}}
 
 // friendlier name to count elements using countElements()
 function count(element_locator) {if (!element_locator) return 0;

--- a/src/tagui_header.js
+++ b/src/tagui_header.js
@@ -203,20 +203,16 @@ return false;}
 
 // friendlier name to use check_tx() in if condition in flow
 function present(element_locator) {if (!element_locator) return false; 
-if (is_sikuli(element_locator))
-{abs_param = abs_file(element_locator); var fs = require('fs');
+if (is_sikuli(element_locator)) {var abs_param = abs_file(element_locator); var fs = require('fs');
 if (!fs.exists(abs_param)) {this.echo('ERROR - cannot find image file for present step').exit();}
-if (sikuli_step("present " + abs_param)) return true;
-else return false;}
+if (sikuli_step("present " + abs_param)) return true; else return false;}
 else return check_tx(element_locator);}
 
 // friendlier name to check element visibility using elementVisible()
 function visible(element_locator) {if (!element_locator) return false;
-if (is_sikuli(element_locator))
-{abs_param = abs_file(element_locator); var fs = require('fs');
+if (is_sikuli(element_locator)) {var abs_param = abs_file(element_locator); var fs = require('fs');
 if (!fs.exists(abs_param)) {this.echo('ERROR - cannot find image file for visible step').exit();}
-if (sikuli_step("visible " + abs_param)) return true;
-else return false;}
+if (sikuli_step("visible " + abs_param)) return true; else return false;}
 else {var element_located = tx(element_locator); var element_visible = casper.elementVisible(element_located);
 // if tx() returns x('/html') means that the element is not found, so set element_visible to false
 if (element_located.toString() == x('/html').toString()) element_visible = false; return element_visible;}}


### PR DESCRIPTION
As discussed in #202 , this allows users to specify image files to the present or visible functions to use Sikuli to determine if they are visible on the screen.

Note that users will need to have some other form of visual automation in the script, e.g. click image.png, to ensure that the Sikuli engine is launched.