### PR TITLE
Feature csv formatting: CSV column count changes

### DIFF
--- a/src/tagui
+++ b/src/tagui
@@ -222,8 +222,8 @@ if [ -f "$1_transpose".csv ]; then php -q transpose.php "$1_transpose".csv | tee
 # check datatable csv file for batch automation
 tagui_data_set_size=1
 if [ -f "$1".csv ]; then
-min_column=`awk -F',' '{print NF}' "$1".csv | sort -nu | head -n 1`
-max_column=`awk -F',' '{print NF}' "$1".csv | sort -nu | tail -n 1`
+# min_column=`awk -F',' '{print NF}' "$1".csv | sort -nu | head -n 1`
+# max_column=`awk -F',' '{print NF}' "$1".csv | sort -nu | tail -n 1`
 # below counts the first row, otherwise edge cases will break this
 min_column=`head -n 1 "$1".csv | awk -F',' '{print NF}'`
 if [ "$min_column" -lt 2 ]; then echo "ERROR - $1.csv has lesser than 2 columns" | tee -a "$1".log

--- a/src/tagui
+++ b/src/tagui
@@ -224,6 +224,8 @@ tagui_data_set_size=1
 if [ -f "$1".csv ]; then
 min_column=`awk -F',' '{print NF}' "$1".csv | sort -nu | head -n 1`
 max_column=`awk -F',' '{print NF}' "$1".csv | sort -nu | tail -n 1`
+# below counts the first row, otherwise edge cases will break this
+min_column=`head -n 1 "$1".csv | awk -F',' '{print NF}'`
 if [ "$min_column" -lt 2 ]; then echo "ERROR - $1.csv has lesser than 2 columns" | tee -a "$1".log
 else tagui_data_set_size="$(($min_column-1))"; fi; fi
 

--- a/src/tagui.cmd
+++ b/src/tagui.cmd
@@ -481,6 +481,8 @@ set tagui_data_set_size=1
 if not exist "%flow_file%.csv" goto no_datatable
 	for /f "tokens=* usebackq" %%c in (`gawk -F"," "{print NF}" "%flow_file%.csv" ^| sort -nu ^| head -n 1`) do set min_column=%%c
 	for /f "tokens=* usebackq" %%c in (`gawk -F"," "{print NF}" "%flow_file%.csv" ^| sort -nu ^| tail -n 1`) do set max_column=%%c
+	rem below counts the first row, otherwise edge cases will break this
+	for /f "tokens=* usebackq" %%c in (`head -n 1 "%flow_file%.csv" ^| gawk -F"," "{print NF}"`) do set min_column=%%c
 
 	if %min_column% lss 2 (
 		echo ERROR - %flow_file%.csv has has lesser than 2 columns | tee -a "%flow_file%.log"

--- a/src/tagui.cmd
+++ b/src/tagui.cmd
@@ -479,8 +479,8 @@ if exist "%flow_file%_transpose.csv" php -q transpose.php "%flow_file%_transpose
 rem check datatable csv file for batch automation
 set tagui_data_set_size=1 
 if not exist "%flow_file%.csv" goto no_datatable
-	for /f "tokens=* usebackq" %%c in (`gawk -F"," "{print NF}" "%flow_file%.csv" ^| sort -nu ^| head -n 1`) do set min_column=%%c
-	for /f "tokens=* usebackq" %%c in (`gawk -F"," "{print NF}" "%flow_file%.csv" ^| sort -nu ^| tail -n 1`) do set max_column=%%c
+	rem for /f "tokens=* usebackq" %%c in (`gawk -F"," "{print NF}" "%flow_file%.csv" ^| sort -nu ^| head -n 1`) do set min_column=%%c
+	rem for /f "tokens=* usebackq" %%c in (`gawk -F"," "{print NF}" "%flow_file%.csv" ^| sort -nu ^| tail -n 1`) do set max_column=%%c
 	rem below counts the first row, otherwise edge cases will break this
 	for /f "tokens=* usebackq" %%c in (`head -n 1 "%flow_file%.csv" ^| gawk -F"," "{print NF}"`) do set min_column=%%c
 

--- a/src/tagui_parse.php
+++ b/src/tagui_parse.php
@@ -282,15 +282,33 @@ function parse_intent($script_line) {$GLOBALS['line_number']++; $GLOBALS['real_l
 $script_line = trim($script_line); if ($script_line=="") {$GLOBALS['real_line_number']--; return "";}
 
 // check existence of objects or keywords by searching for `object or keyword name`, then expand from repository
-if ((substr_count($script_line,'`') > 1) and (!(substr_count($script_line,'`') & 1))) { // check for even number of `
-if ($GLOBALS['repo_count'] == 0) echo "ERROR - ".current_line()." no repository data for ".$script_line."\n";
-// loop through repository data to search and replace definitions, do it twice to handle objects within keywords
-else {if (getenv('tagui_data_set')!==false) $data_set = intval(getenv('tagui_data_set')); else $data_set = 1;
-for ($repo_check = 0; $repo_check <= $GLOBALS['repo_count']; $repo_check++) $script_line =
-str_replace("`".$GLOBALS['repo_data'][$repo_check][0]."`",$GLOBALS['repo_data'][$repo_check][$data_set],$script_line);
-for ($repo_check = 0; $repo_check <= $GLOBALS['repo_count']; $repo_check++) $script_line =
-str_replace("`".$GLOBALS['repo_data'][$repo_check][0]."`",$GLOBALS['repo_data'][$repo_check][$data_set],$script_line);
-if (strpos($script_line,'`')!==false) echo "ERROR - ".current_line()." no repository data for ".$script_line."\n";}}
+// check for even number of `
+if ((substr_count($script_line,'`') > 1) and (!(substr_count($script_line,'`') & 1))) {
+	if ($GLOBALS['repo_count'] == 0) {
+		echo "ERROR - ".current_line()." no repository data for ".$script_line."\n";
+	} else {
+		if (getenv('tagui_data_set')!==false) {
+			$data_set = intval(getenv('tagui_data_set'));
+		} else {
+			$data_set = 1;
+		}
+		$escaped_line_ends = ["\n" => "\\n", "\r" => "\\r"];
+		// loop through repository data to search and replace definitions, do it twice to handle objects within keywords
+		for ($repo_check = 0; $repo_check <= $GLOBALS['repo_count']; $repo_check++) {
+			$repo_keyword = "`".$GLOBALS['repo_data'][$repo_check][0]."`";
+			$repo_data_value = strtr($GLOBALS['repo_data'][$repo_check][$data_set], $escaped_line_ends);
+			$script_line = str_replace($repo_keyword, $repo_data_value, $script_line);
+		}
+		for ($repo_check = 0; $repo_check <= $GLOBALS['repo_count']; $repo_check++) {
+			$repo_keyword = "`".$GLOBALS['repo_data'][$repo_check][0]."`";
+			$repo_data_value = strtr($GLOBALS['repo_data'][$repo_check][$data_set], $escaped_line_ends);
+			$script_line = str_replace($repo_keyword, $repo_data_value, $script_line);
+		}
+		if (strpos($script_line,'`')!==false) {
+			echo "ERROR - ".current_line()." no repository data for ".$script_line."\n";
+		}
+	}
+}
 
 // trim and check again after replacing definitions from repository
 $script_line = trim($script_line); if ($script_line=="") {$GLOBALS['real_line_number']--; return "";}


### PR DESCRIPTION
CSV column count changed from calculating the minimum number of  commas `,` in each line of the CSV to just taking the number of commas `,` from the first line of the CSV.

This is based on the user's assumption that the first column of the CSV would always contain the correct number of `,` and as such, the correct number of iterations to run.

In addition, fixed breaking bug relating to line breaks in the CSV data field by replacing the line breaks with their corresponding newline characters `\n` and `\r`, if they exist.