### PR TITLE
Update popup handling when using Chrome.

### DIFF
--- a/src/tagui_header.js
+++ b/src/tagui_header.js
@@ -610,7 +610,7 @@ try {var ws_json = JSON.parse(ws_message); if (ws_json.result.targetInfos) chrom
 else chrome_targets = [];} catch(e) {chrome_targets = [];} // following line scan through targets to find match
 chrome_targets.forEach(function(target) {if (target.url.search(popupInfo) !== -1) found_targetid = target.targetId;});
 if (found_targetid !== '') {var ws_message = chrome_step('Target.attachToTarget',{targetId: found_targetid});
-try {var ws_json = JSON.parse(ws_message); if (ws_json.result.sessionId.indexOf(found_targetid) > -1)
+try {var ws_json = JSON.parse(ws_message); if (ws_json.result.sessionId !== '')
 found_targetid = ws_json.result.sessionId; else found_targetid = '';} catch(e) {found_targetid = ''};}
 chrome_targetid = found_targetid;}); // set chrome_targetid only after attaching to found target successfully
 casper.then(then); casper.then(function _step() {if (chrome_targetid !== '') // detach from target after running then

--- a/src/test/positive_test.signature
+++ b/src/test/positive_test.signature
@@ -637,7 +637,7 @@ try {var ws_json = JSON.parse(ws_message); if (ws_json.result.targetInfos) chrom
 else chrome_targets = [];} catch(e) {chrome_targets = [];} // following line scan through targets to find match
 chrome_targets.forEach(function(target) {if (target.url.search(popupInfo) !== -1) found_targetid = target.targetId;});
 if (found_targetid !== '') {var ws_message = chrome_step('Target.attachToTarget',{targetId: found_targetid});
-try {var ws_json = JSON.parse(ws_message); if (ws_json.result.sessionId.indexOf(found_targetid) > -1)
+try {var ws_json = JSON.parse(ws_message); if (ws_json.result.sessionId !== '')
 found_targetid = ws_json.result.sessionId; else found_targetid = '';} catch(e) {found_targetid = ''};}
 chrome_targetid = found_targetid;}); // set chrome_targetid only after attaching to found target successfully
 casper.then(then); casper.then(function _step() {if (chrome_targetid !== '') // detach from target after running then
@@ -1314,6 +1314,7 @@ function getTimeoutAndCheckNextStepFunction(timeout, then, methodName, defaultTi
 
     return timeout;
 }
+
 
 // flow path for save_text and snap_image
 var flow_path = '/full_path';


### PR DESCRIPTION
Due to changes in Chrome version 69, the original method of handling popups no longer successfully recognises and attaches to the popup window/tab. This changes the check to look for a successful sessionID.

For details check issue #275