### PR TITLE
Potential fix for #289 and #295

### DIFF
--- a/src/tagui_parse.php
+++ b/src/tagui_parse.php
@@ -16,9 +16,8 @@ $config_file = fopen('tagui_config.txt','r') or die("ERROR - cannot open tagui_c
 $header_file = fopen('tagui_header.js','r') or die("ERROR - cannot open tagui_header.js" . "\n");
 $footer_file = fopen('tagui_footer.js','r') or die("ERROR - cannot open tagui_footer.js" . "\n");
 
-$repo_count = 0; if (file_exists(getenv('custom_csv_file'))) { // load repository file for objects and keywords
+$repo_count = 0; if (file_exists(getenv('custom_csv_file'))) { // load datatable or legacy datatable / repository
 $repo_file = fopen(getenv('custom_csv_file'),'r') or die("ERROR - cannot open " . getenv('custom_csv_file') . "\n");
-fgetcsv($repo_file); // discard header record without incrementing counter
 while (!feof($repo_file)) {$repo_data[$repo_count] = fgetcsv($repo_file);
 if (count($repo_data[$repo_count]) == 0) die("ERROR - empty row found in " . getenv('custom_csv_file') . "\n");
 $repo_count++;} fclose($repo_file); $repo_count-=1; //-1 for header, for EOF need to check flexibly using below line
@@ -27,7 +26,7 @@ if (count($repo_data[$repo_count]) == 1) $repo_count-=1;} //-1 for EOF (Windows 
 $local_repo_location = str_replace("\\","/",dirname($script)) . '/tagui_local.csv';
 if (file_exists($local_repo_location)) { // load local repository file if it exists for objects and keywords
 $local_repo_file = fopen($local_repo_location,'r') or die("ERROR - cannot open " . 'tagui_local.csv' . "\n");
-fgetcsv($local_repo_file); // discard header record without incrementing counter
+if ($repo_count != 0) $repo_count++; fgetcsv($local_repo_file); // +1 if array has data, discard header record
 while (!feof($local_repo_file)) {$repo_data[$repo_count] = fgetcsv($local_repo_file);
 if (count($repo_data[$repo_count]) == 0) die("ERROR - empty row found in " . 'tagui_local.csv' . "\n");
 if (count($repo_data[$repo_count]) != 1) // pad the empty columns when local repository is used with datatable
@@ -36,7 +35,7 @@ $repo_count++;} fclose($local_repo_file); $repo_count-=1; if (count($repo_data[$
 
 if (file_exists('tagui_global.csv')) { // load global repository file if it exists for objects and keywords
 $global_repo_file = fopen('tagui_global.csv','r') or die("ERROR - cannot open " . 'tagui_global.csv' . "\n");
-fgetcsv($global_repo_file); // discard header record without incrementing counter
+if ($repo_count != 0) $repo_count++; fgetcsv($global_repo_file); // +1 if array has data, discard header record
 while (!feof($global_repo_file)) {$repo_data[$repo_count] = fgetcsv($global_repo_file);
 if (count($repo_data[$repo_count]) == 0) die("ERROR - empty row found in " . 'tagui_global.csv' . "\n");
 if (count($repo_data[$repo_count]) != 1) // pad the empty columns when global repository is used with datatable

--- a/src/tagui_parse.php
+++ b/src/tagui_parse.php
@@ -18,6 +18,7 @@ $footer_file = fopen('tagui_footer.js','r') or die("ERROR - cannot open tagui_fo
 
 $repo_count = 0; if (file_exists(getenv('custom_csv_file'))) { // load repository file for objects and keywords
 $repo_file = fopen(getenv('custom_csv_file'),'r') or die("ERROR - cannot open " . getenv('custom_csv_file') . "\n");
+fgetcsv($repo_file); // discard header record without incrementing counter
 while (!feof($repo_file)) {$repo_data[$repo_count] = fgetcsv($repo_file);
 if (count($repo_data[$repo_count]) == 0) die("ERROR - empty row found in " . getenv('custom_csv_file') . "\n");
 $repo_count++;} fclose($repo_file); $repo_count-=1; //-1 for header, for EOF need to check flexibly using below line
@@ -26,7 +27,7 @@ if (count($repo_data[$repo_count]) == 1) $repo_count-=1;} //-1 for EOF (Windows 
 $local_repo_location = str_replace("\\","/",dirname($script)) . '/tagui_local.csv';
 if (file_exists($local_repo_location)) { // load local repository file if it exists for objects and keywords
 $local_repo_file = fopen($local_repo_location,'r') or die("ERROR - cannot open " . 'tagui_local.csv' . "\n");
-$repo_count++; fgetcsv($local_repo_file); // increase repo_count to prep for read, discard header record
+fgetcsv($local_repo_file); // discard header record without incrementing counter
 while (!feof($local_repo_file)) {$repo_data[$repo_count] = fgetcsv($local_repo_file);
 if (count($repo_data[$repo_count]) == 0) die("ERROR - empty row found in " . 'tagui_local.csv' . "\n");
 if (count($repo_data[$repo_count]) != 1) // pad the empty columns when local repository is used with datatable
@@ -35,7 +36,7 @@ $repo_count++;} fclose($local_repo_file); $repo_count-=1; if (count($repo_data[$
 
 if (file_exists('tagui_global.csv')) { // load global repository file if it exists for objects and keywords
 $global_repo_file = fopen('tagui_global.csv','r') or die("ERROR - cannot open " . 'tagui_global.csv' . "\n");
-$repo_count++; fgetcsv($global_repo_file); // increase repo_count to prep for read, discard header record
+fgetcsv($global_repo_file); // discard header record without incrementing counter
 while (!feof($global_repo_file)) {$repo_data[$repo_count] = fgetcsv($global_repo_file);
 if (count($repo_data[$repo_count]) == 0) die("ERROR - empty row found in " . 'tagui_global.csv' . "\n");
 if (count($repo_data[$repo_count]) != 1) // pad the empty columns when global repository is used with datatable
@@ -803,9 +804,9 @@ function wait_intent($raw_intent) {
 $params = trim(substr($raw_intent." ",1+strpos($raw_intent." "," "))); if ($params == "") $params = "5";
 if (strpos($params,"'+")!==false and strpos($params,"+'")!==false) // handling for dynamic time
 return "casper.then(function() {".
-"techo('".$raw_intent."');});\ncasper.wait((parseFloat('".$params."')*1000), function() {"."});"."\n\n";
+"techo('".$raw_intent."');});\ncasper.then(function() {casper.wait((parseFloat('".$params."')*1000), function() {"."});});"."\n\n";
 else return "casper.then(function() {".
-"techo('".$raw_intent."');});\ncasper.wait(" . (floatval($params)*1000) . ", function() {"."});"."\n\n";}
+"techo('".$raw_intent."');});\ncasper.then(function() {casper.wait(" . (floatval($params)*1000) . ", function() {"."});});"."\n\n";}
 
 function live_intent($raw_intent) { // live mode to interactively test tagui steps and js code (casperjs context)
 return "casper.then(function() {".

--- a/src/test/positive_test.signature
+++ b/src/test/positive_test.signature
@@ -1315,7 +1315,6 @@ function getTimeoutAndCheckNextStepFunction(timeout, then, methodName, defaultTi
     return timeout;
 }
 
-
 // flow path for save_text and snap_image
 var flow_path = '/full_path';
 
@@ -2490,43 +2489,43 @@ if (resource.url.indexOf('report') > -1) this.download(resource.url, '/tmp/filen
 
 // test wait
 casper.then(function() {techo('wait');});
-casper.wait(5000, function() {});
+casper.then(function() {casper.wait(5000, function() {});});
 
 casper.then(function() {techo('wait 2.5');});
-casper.wait(2500, function() {});
+casper.then(function() {casper.wait(2500, function() {});});
 
 casper.then(function() {techo('wait 10.0');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10s');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10sec');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10secs');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10seconds');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10 s');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10 sec');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10 secs');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 10 seconds');});
-casper.wait(10000, function() {});
+casper.then(function() {casper.wait(10000, function() {});});
 
 casper.then(function() {techo('wait 7.5 seconds');});
-casper.wait(7500, function() {});
+casper.then(function() {casper.wait(7500, function() {});});
 
 // test live
 casper.then(function() {{var live_input = '';
@@ -2936,7 +2935,7 @@ start = timer()
 }); // end of JS code
 
 casper.then(function() {techo('wait 3 seconds');});
-casper.wait(3000, function() {});
+casper.then(function() {casper.wait(3000, function() {});});
 
 casper.then(function() { // start of JS code
 time_taken = timer()


### PR DESCRIPTION
#289 - enclose wait step with casper.then() in order to make dynamic wait delay in scope for access

#295 - PHP 7 issues warning message which is not observed with PHP 5. this change removes the warning by avoiding an empty $repo_data[0]. ie increment repo_count only if there is already data in the array, otherwise discard header and start filling from $repo_data[0]. For the datatable (custom_csv_file portion), don't drop header as there is a dummy [iteration] header to let users reference current datatable iteration number.