### PR TITLE
#321 - update readme with tagui editor gif video

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ TagUI Writer is a Windows app created by [@adegard](https://github.com/adegard) 
 
 <details>
   <summary>
-    Click to show a preview of how TagUI Writer looks like (it works across different editors)
+    Click to show a preview of how TagUI Editor can be used to edit and run TagUI scripts
   </summary>
 
-![TagUI Writer](https://raw.githubusercontent.com/kelaberetiv/TagUI/master/src/media/tagui_writer.png)
+![TagUI Editor](https://raw.githubusercontent.com/adegard/tagui_scripts/master/TagUI_Editor.gif)
 
 </details>
 


### PR DESCRIPTION
Hi @ryzalk and @Aussiroth , adding on to Alvin's update, this PR updates readme to point to the gif video for @adegard 's TagUI Editor. The gif is hosted at Arnaud's repo and is < 2MB so it's ok to put that instead of having a static TagUI Writer screenshot.

PS - I edited on a patch branch as my own repo at tebelorg has overly verbose commit history to be desirable to merge upstream here.