### PR TITLE
#417 - helper scripts to kill processes if Ctrl+C is used

### DIFF
--- a/src/end_processes
+++ b/src/end_processes
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# TO KILL INTEGRATION PROCESSES IF CTRL+C WAS USED TO QUIT TAGUI PREMATURELY ~ TEBEL.ORG #
+
+# checking for existence of files before sending finish signal is important
+# otherwise for ongoing tagui iterations, all integrations will be invoked
+
+if [ -f "tagui_r/tagui_r.in" ]; then echo "finish" > tagui_r/tagui_r.in; fi
+if [ -f "tagui_py/tagui_py.in" ]; then echo "finish" > tagui_py/tagui_py.in; fi
+if [ -f "tagui.sikuli/tagui_sikuli.in" ]; then echo "finish" > tagui.sikuli/tagui_sikuli.in; fi
+if [ -f "tagui_chrome.in" ]; then echo "finish" > tagui_chrome.in; fi

--- a/src/end_processes.cmd
+++ b/src/end_processes.cmd
@@ -1,0 +1,10 @@
+@echo off
+rem # TO KILL INTEGRATION PROCESSES IF CTRL+C WAS USED TO QUIT TAGUI PREMATURELY ~ TEBEL.ORG #
+
+rem checking for existence of files before sending finish signal is important
+rem otherwise for ongoing tagui iterations, all integrations will be invoked
+
+if exist "tagui_r\tagui_r.in" echo finish > tagui_r\tagui_r.in
+if exist "tagui_py\tagui_py.in" echo finish > tagui_py\tagui_py.in
+if exist "tagui.sikuli\tagui_sikuli.in" echo finish > tagui.sikuli\tagui_sikuli.in
+if exist "tagui_chrome.in" echo finish > tagui_chrome.in

--- a/src/tagui_header.js
+++ b/src/tagui_header.js
@@ -342,6 +342,11 @@ return fs.read('tagui.sikuli'+ds+'tagui_sikuli.txt').trim(); else return '';}
 function clear_sikuli_text() {var ds; if (flow_path.indexOf('/') !== -1) ds = '/'; else ds = '\\';
 var fs = require('fs'); fs.write('tagui.sikuli'+ds+'tagui_sikuli.txt','','w');}
 
+// for setting timeout in sikuli when looking for ui element
+function sikuli_timeout(time_in_seconds) {var ds; if (flow_path.indexOf('/') !== -1) ds = '/'; else ds = '\\';
+var fs = require('fs'); if (fs.exists('tagui.sikuli'+ds+'tagui_sikuli.in'))
+sikuli_step('vision setAutoWaitTimeout(' + time_in_seconds.toString() + ')');}
+
 // for initialising integration with R
 function r_handshake() { // techo('[connecting to R process]');
 var ds; if (flow_path.indexOf('/') !== -1) ds = '/'; else ds = '\\'; clear_r_text();
@@ -1175,7 +1180,7 @@ else return call_sikuli(raw_intent.replace(/\\/g,'\\\\').replace(/'/g,'\\\''),'f
 function timeout_intent(raw_intent) {raw_intent = eval("'" + escape_bs(raw_intent) + "'"); // support dynamic variables
 var params = ((raw_intent + ' ').substr(1+(raw_intent + ' ').indexOf(' '))).trim();
 if (params == '') return "this.echo('ERROR - time in seconds missing for " + raw_intent + "')";
-else return check_chrome_context("casper.options.waitTimeout = " + (parseFloat(params)*1000).toString() + ";");}
+else return check_chrome_context("casper.options.waitTimeout = " + (parseFloat(params)*1000).toString() + "; sikuli_timeout(" + parseFloat(params).toString() + ");");}
 
 function code_intent(raw_intent) { // code to support dynamic variables not applicable
 return check_chrome_context(raw_intent);}

--- a/src/tagui_parse.php
+++ b/src/tagui_parse.php
@@ -964,7 +964,8 @@ return "casper.then(function() {".call_sikuli($safe_intent,'for vision step');} 
 function timeout_intent($raw_intent) {
 $params = trim(substr($raw_intent." ",1+strpos($raw_intent." "," ")));
 if ($params == "") echo "ERROR - " . current_line() . " time in seconds missing for " . $raw_intent . "\n";
-else return "casper.then(function() {"."casper.options.waitTimeout = " . (floatval($params)*1000) . ";" . end_fi()."});"."\n\n";}
+else return "casper.then(function() {"."casper.options.waitTimeout = " . (floatval($params)*1000) . 
+"; sikuli_timeout(" . floatval($params) . ");" . end_fi()."});"."\n\n";}
 
 function code_intent($raw_intent) {
 $params = parse_condition($raw_intent);

--- a/src/test/positive_test.signature
+++ b/src/test/positive_test.signature
@@ -369,6 +369,11 @@ return fs.read('tagui.sikuli'+ds+'tagui_sikuli.txt').trim(); else return '';}
 function clear_sikuli_text() {var ds; if (flow_path.indexOf('/') !== -1) ds = '/'; else ds = '\\';
 var fs = require('fs'); fs.write('tagui.sikuli'+ds+'tagui_sikuli.txt','','w');}
 
+// for setting timeout in sikuli when looking for ui element
+function sikuli_timeout(time_in_seconds) {var ds; if (flow_path.indexOf('/') !== -1) ds = '/'; else ds = '\\';
+var fs = require('fs'); if (fs.exists('tagui.sikuli'+ds+'tagui_sikuli.in'))
+sikuli_step('vision setAutoWaitTimeout(' + time_in_seconds.toString() + ')');}
+
 // for initialising integration with R
 function r_handshake() { // techo('[connecting to R process]');
 var ds; if (flow_path.indexOf('/') !== -1) ds = '/'; else ds = '\\'; clear_r_text();
@@ -1202,7 +1207,7 @@ else return call_sikuli(raw_intent.replace(/\\/g,'\\\\').replace(/'/g,'\\\''),'f
 function timeout_intent(raw_intent) {raw_intent = eval("'" + escape_bs(raw_intent) + "'"); // support dynamic variables
 var params = ((raw_intent + ' ').substr(1+(raw_intent + ' ').indexOf(' '))).trim();
 if (params == '') return "this.echo('ERROR - time in seconds missing for " + raw_intent + "')";
-else return check_chrome_context("casper.options.waitTimeout = " + (parseFloat(params)*1000).toString() + ";");}
+else return check_chrome_context("casper.options.waitTimeout = " + (parseFloat(params)*1000).toString() + "; sikuli_timeout(" + parseFloat(params).toString() + ");");}
 
 function code_intent(raw_intent) { // code to support dynamic variables not applicable
 return check_chrome_context(raw_intent);}
@@ -2984,11 +2989,11 @@ this.echo('ERROR - cannot find image file for vision step').exit(); else
 this.echo('ERROR - cannot find for vision step on screen').exit(); this.wait(0);}});
 
 // test timeout
-casper.then(function() {casper.options.waitTimeout = 4000;});
+casper.then(function() {casper.options.waitTimeout = 4000; sikuli_timeout(4);});
 
-casper.then(function() {casper.options.waitTimeout = 5670;});
+casper.then(function() {casper.options.waitTimeout = 5670; sikuli_timeout(5.67);});
 
-casper.then(function() {casper.options.waitTimeout = 6000;});
+casper.then(function() {casper.options.waitTimeout = 6000; sikuli_timeout(6);});
 
 // test comment
 // user comment with space


### PR DESCRIPTION
Committing helper scripts that can be used to kill integration processes if user use Ctrl+C to terminate TagUI prematurely and TagUI can't shutdown the running integration processes.

More details at #417