### PR TITLE
Deploy without .tag in the generated deploy file

### DIFF
--- a/src/tagui
+++ b/src/tagui
@@ -95,10 +95,10 @@ if [ "$6" = "-deploy" ] || [ "$6" = "-d" ]; then set -- "${@:1:5}" "${@:7}"; tag
 if [ "$7" = "-deploy" ] || [ "$7" = "-d" ]; then set -- "${@:1:6}" "${@:8}"; tagui_deploy_workflow=true; fi
 if [ "$8" = "-deploy" ] || [ "$8" = "-d" ]; then set -- "${@:1:7}" "${@:9}"; tagui_deploy_workflow=true; fi
 if [ "$9" = "-deploy" ] || [ "$9" = "-d" ]; then set -- "${@:1:8}"; tagui_deploy_workflow=true; fi
-if [ "$tagui_deploy_workflow" == true ]; then echo cd \""$initial_dir"\" > "$1".command
-echo \""$TAGUI_DIR/tagui"\" \""$1"\" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" >> "$1".command
-echo "INFO - deployment script $1.command generated"
-chmod 700 "$1".command; exit 0; fi
+if [ "$tagui_deploy_workflow" == true ]; then echo cd \""$initial_dir"\" > "${1%.tag}".command
+echo \""$TAGUI_DIR/tagui"\" \""$1"\" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" >> "${1%.tag}".command
+echo "INFO - deployment script ${1%.tag}.command generated"
+chmod 700 "${1%.tag}".command; exit 0; fi
 
 # set default web browser to be used to chrome
 tagui_web_browser="chrome"

--- a/src/tagui.cmd
+++ b/src/tagui.cmd
@@ -255,10 +255,10 @@ if "%arg9%"=="-d" (
 )
 
 if %tagui_deploy_workflow%==true (
-	echo @echo off > "%flow_file%.cmd"
-	echo cd /d "%initial_dir%" >> "%flow_file%.cmd"
-	echo "%~dp0tagui" "%flow_file%" %arg2% %arg3% %arg4% %arg5% %arg6% %arg7% %arg8% %arg9% >> "%flow_file%.cmd"
-	echo INFO - deployment script %flow_file%.cmd generated
+	echo @echo off > "%flow_file:~0,-4%.cmd"
+	echo cd /d "%initial_dir%" >> "%flow_file:~0,-4%.cmd"
+	echo "%~dp0tagui" "%flow_file%" %arg2% %arg3% %arg4% %arg5% %arg6% %arg7% %arg8% %arg9% >> "%flow_file:~0,-4%.cmd"
+	echo INFO - deployment script %flow_file:~0,-4%.cmd generated
 	exit /b 0
 )
 


### PR DESCRIPTION
Solution for mac/Linux -
https://unix.stackexchange.com/questions/144298/delete-the-last-character-of-a-string-using-string-manipulation-in-shell-script

Solution for Windows -
https://stackoverflow.com/questions/29503925/remove-last-characters-string-batch/29504225