### PR TITLE
#655 feat: adds indentation instead of curly braces for and if blocks

### DIFF
--- a/src/tagui_parse.php
+++ b/src/tagui_parse.php
@@ -180,7 +180,13 @@ if ((substr($padded_raw_flow_line,0,3)=="if ") or (substr($padded_raw_flow_line,
 or (substr($padded_raw_flow_line,0,4)=="for ") or (substr($padded_raw_flow_line,0,6)=="while ") or
 (substr($padded_raw_flow_line,0,6)=="popup ") or (substr($padded_raw_flow_line,0,6)=="frame ") or
 (trim($padded_raw_flow_line)=="else")) $current_line_is_condition = true; else $current_line_is_condition = false;
-$padded_raw_flow .= $padded_raw_flow_line;
+
+if (($previous_line_is_condition == true) and ($current_line_is_condition == true))
+die("ERROR - for nested conditions, loops, popup, frame, set { and } explicitly\n".	
+"ERROR - add { before this line and add } accordingly - ".$padded_raw_flow_line);	
+if (($previous_line_is_condition == true) and (substr($padded_raw_flow_line,0,1)!="{"))	
+$padded_raw_flow .= "{\n".trim($padded_raw_flow_line)."\n}\n"; else $padded_raw_flow .= $padded_raw_flow_line;
+
 $previous_line_is_condition = $current_line_is_condition; // prepare for next line
 } 
 fclose($input_file); file_put_contents($script . '.raw', $padded_raw_flow);


### PR DESCRIPTION
TESTED with the following cases

(1) simple case for
```
for n from 1 to 3
    echo n
```

(2) simple case if
```
if 5 more than 3
    echo 1
    echo 2
    if 5 more than 3
        echo 3
    echo 4
```

(3) dropping down two levels of indentation
```
if 5 more than 3
    echo 1
    echo 2
    if 5 more than 3
        echo 3
```

(4) test for backward compatibility (the output repeats the curly braces, which is ugly but the code still works)
```
for n from 1 to 3
{
    echo n
}
```

(5) test with python integration
```
py begin
for i in range(5):
    print(i)
py finish

for n from 1 to 3
    echo n
```

(6) test for inconsistent numbers of spaces -  the code errors out with *ERROR - use a consistent number of spaces for indentation*
```
if 5 more than 3
    echo 1
    echo 2
    if 5 more than 3
        echo 3
      echo 4
```